### PR TITLE
Fixed Infinity-bug in perfectScale

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -739,7 +739,7 @@ Blocks.prototype.doLoad = function(scene, init)
  */
 Blocks.prototype.perfectScale = function()
 {
-    if (!this.div) {
+    if (!this.div || this.blocks.length === 0) {
         return;
     }
 


### PR DESCRIPTION
Calling perfectScale with no blocks the scale will be set to Infinity, which will position all new blocks in the top left corner. The added blocks can't be moved until perfectScale is called again.